### PR TITLE
Return trainer ID from context

### DIFF
--- a/cmd/middleware.go
+++ b/cmd/middleware.go
@@ -124,8 +124,8 @@ func (app *application) JWTMiddleware(next http.Handler, requiredRole string) ht
 		ctx := context.WithValue(r.Context(), "user_id", int(claims.UserID))
 		ctx = context.WithValue(ctx, "role", claims.Role)
 
-		// Передаем управление следующему обработчику
-		next.ServeHTTP(w, r)
+		// Передаем управление следующему обработчику вместе с новым контекстом
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -31,7 +31,7 @@ func (app *application) routes() http.Handler {
 
 	// Programs
 	mux.Post("/program", trainerAuthMiddleware.ThenFunc(app.programHandler.CreateProgram))
-	mux.Get("/programs", standardMiddleware.ThenFunc(app.programHandler.ProgramsByTrainer))
+	mux.Get("/programs", trainerAuthMiddleware.ThenFunc(app.programHandler.ProgramsByTrainer))
 
 	// Exercises and Food
 	mux.Post("/exercise", trainerAuthMiddleware.ThenFunc(app.exerciseHandler.CreateExercise))

--- a/internal/handlers/program_handler.go
+++ b/internal/handlers/program_handler.go
@@ -22,6 +22,13 @@ func (h *ProgramHandler) CreateProgram(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if userID, ok := r.Context().Value("user_id").(int); ok {
+		p.TrainerID = userID
+	} else {
+		http.Error(w, "user id missing", http.StatusUnauthorized)
+		return
+	}
+
 	created, err := h.Service.CreateProgram(r.Context(), p)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -37,6 +44,12 @@ func (h *ProgramHandler) CreateProgram(w http.ResponseWriter, r *http.Request) {
 func (h *ProgramHandler) ProgramsByTrainer(w http.ResponseWriter, r *http.Request) {
 	trainerIDStr := r.URL.Query().Get("trainer_id")
 	trainerID, _ := strconv.Atoi(trainerIDStr)
+
+	if trainerID == 0 {
+		if id, ok := r.Context().Value("user_id").(int); ok {
+			trainerID = id
+		}
+	}
 
 	programs, err := h.Service.ProgramsByTrainer(r.Context(), trainerID)
 	if err != nil {

--- a/internal/repositories/program_repository.go
+++ b/internal/repositories/program_repository.go
@@ -43,7 +43,7 @@ WHERE trainer_id = ?
 	}
 	defer rows.Close()
 
-	var programs []models.WorkOutProgram
+	programs := []models.WorkOutProgram{}
 	for rows.Next() {
 		var p models.WorkOutProgram
 		if err := rows.Scan(&p.ID, &p.TrainerID, &p.Name, &p.Days, &p.Description, &p.CreatedAt, &p.UpdatedAt); err != nil {


### PR DESCRIPTION
## Summary
- set trainer ID from auth context when creating programs to ensure they're associated with the correct trainer
- require authentication for listing programs and fall back to the authenticated trainer when no query parameter is supplied

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go build ./cmd` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686bcff4b5a483249083836d1a3b1b88