### PR TITLE
Return trainer ID from context

### DIFF
--- a/cmd/middleware.go
+++ b/cmd/middleware.go
@@ -124,8 +124,8 @@ func (app *application) JWTMiddleware(next http.Handler, requiredRole string) ht
 		ctx := context.WithValue(r.Context(), "user_id", int(claims.UserID))
 		ctx = context.WithValue(ctx, "role", claims.Role)
 
-		// Передаем управление следующему обработчику
-		next.ServeHTTP(w, r)
+		// Передаем управление следующему обработчику вместе с новым контекстом
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -31,17 +31,20 @@ func (app *application) routes() http.Handler {
 
 	// Programs
 	mux.Post("/program", trainerAuthMiddleware.ThenFunc(app.programHandler.CreateProgram))
-	mux.Get("/programs", standardMiddleware.ThenFunc(app.programHandler.ProgramsByTrainer))
+	mux.Get("/programs", trainerAuthMiddleware.ThenFunc(app.programHandler.ProgramsByTrainer))
+	mux.Get("/program/:id", trainerAuthMiddleware.ThenFunc(app.programHandler.GetProgram))
+	mux.Put("/program/:id", trainerAuthMiddleware.ThenFunc(app.programHandler.UpdateProgram))
+	mux.Del("/program/:id", trainerAuthMiddleware.ThenFunc(app.programHandler.DeleteProgram))
 
 	// Exercises and Food
 	mux.Post("/exercise", trainerAuthMiddleware.ThenFunc(app.exerciseHandler.CreateExercise))
 	mux.Post("/food", trainerAuthMiddleware.ThenFunc(app.foodHandler.CreateFood))
 
 	// Days
-	mux.Get("/program/day", standardMiddleware.ThenFunc(app.dayHandler.DayDetails))
+	mux.Get("/program/:program_id/days", trainerAuthMiddleware.ThenFunc(app.dayHandler.DaysByProgram))
+	mux.Get("/program/:program_id/day/:day", trainerAuthMiddleware.ThenFunc(app.dayHandler.DayDetails))
 	mux.Post("/program/day/complete", standardMiddleware.ThenFunc(app.dayHandler.CompleteDay))
 	mux.Post("/program/day", trainerAuthMiddleware.ThenFunc(app.dayHandler.CreateDay))
-	mux.Post("/program/day/complete", standardMiddleware.ThenFunc(app.dayHandler.CompleteDay))
 
 	// mux.Get("/swagger/", httpSwagger.WrapHandler)
 

--- a/internal/handlers/day_handler.go
+++ b/internal/handlers/day_handler.go
@@ -2,8 +2,10 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
+
 	"workout/internal/models"
 	"workout/internal/services"
 )
@@ -15,13 +17,31 @@ type DayHandler struct {
 
 // DayDetails returns exercises and food for a specific day in a program.
 func (h *DayHandler) DayDetails(w http.ResponseWriter, r *http.Request) {
-	programID, _ := strconv.Atoi(r.URL.Query().Get("program_id"))
-	dayNum, _ := strconv.Atoi(r.URL.Query().Get("day"))
+	programID, _ := strconv.Atoi(r.URL.Query().Get(":program_id"))
+	if programID == 0 {
+		programID, _ = strconv.Atoi(r.URL.Query().Get("program_id"))
+	}
+
+	dayNum, _ := strconv.Atoi(r.URL.Query().Get(":day"))
+	if dayNum == 0 {
+		dayNum, _ = strconv.Atoi(r.URL.Query().Get("day"))
+	}
+
+	if programID == 0 || dayNum == 0 {
+		http.Error(w, "program_id and day are required", http.StatusBadRequest)
+		return
+	}
+
 	details, err := h.Service.GetDay(r.Context(), programID, dayNum)
 	if err != nil {
+		if errors.Is(err, models.ErrDayNotFound) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(details)
 }
@@ -53,7 +73,11 @@ func (h *DayHandler) CreateDay(w http.ResponseWriter, r *http.Request) {
 	}
 	created, err := h.Service.CreateDay(r.Context(), day)
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		status := http.StatusInternalServerError
+		if errors.Is(err, models.ErrWorkoutProgramNotFound) || errors.Is(err, models.ErrExerciseNotFound) || errors.Is(err, models.ErrFoodNotFound) {
+			status = http.StatusBadRequest
+		}
+		http.Error(w, err.Error(), status)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -63,7 +87,15 @@ func (h *DayHandler) CreateDay(w http.ResponseWriter, r *http.Request) {
 
 // DaysByProgram returns all days with details for a program.
 func (h *DayHandler) DaysByProgram(w http.ResponseWriter, r *http.Request) {
-	programID, _ := strconv.Atoi(r.URL.Query().Get("program_id"))
+	programID, _ := strconv.Atoi(r.URL.Query().Get(":program_id"))
+	if programID == 0 {
+		programID, _ = strconv.Atoi(r.URL.Query().Get("program_id"))
+	}
+	if programID == 0 {
+		http.Error(w, "program_id required", http.StatusBadRequest)
+		return
+	}
+
 	days, err := h.Service.DaysByProgram(r.Context(), programID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/internal/handlers/program_handler.go
+++ b/internal/handlers/program_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 
@@ -22,6 +23,13 @@ func (h *ProgramHandler) CreateProgram(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if userID, ok := r.Context().Value("user_id").(int); ok {
+		p.TrainerID = userID
+	} else {
+		http.Error(w, "user id missing", http.StatusUnauthorized)
+		return
+	}
+
 	created, err := h.Service.CreateProgram(r.Context(), p)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -38,6 +46,12 @@ func (h *ProgramHandler) ProgramsByTrainer(w http.ResponseWriter, r *http.Reques
 	trainerIDStr := r.URL.Query().Get("trainer_id")
 	trainerID, _ := strconv.Atoi(trainerIDStr)
 
+	if trainerID == 0 {
+		if id, ok := r.Context().Value("user_id").(int); ok {
+			trainerID = id
+		}
+	}
+
 	programs, err := h.Service.ProgramsByTrainer(r.Context(), trainerID)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -46,4 +60,83 @@ func (h *ProgramHandler) ProgramsByTrainer(w http.ResponseWriter, r *http.Reques
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(programs)
+}
+
+// GetProgram returns a workout program by id.
+func (h *ProgramHandler) GetProgram(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(r.URL.Query().Get(":id"))
+	if id == 0 {
+		id, _ = strconv.Atoi(r.URL.Query().Get("id"))
+	}
+	if id == 0 {
+		http.Error(w, "id required", http.StatusBadRequest)
+		return
+	}
+
+	p, err := h.Service.ProgramByID(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, models.ErrWorkoutProgramNotFound) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(p)
+}
+
+// UpdateProgram edits an existing workout program.
+func (h *ProgramHandler) UpdateProgram(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(r.URL.Query().Get(":id"))
+	if id == 0 {
+		id, _ = strconv.Atoi(r.URL.Query().Get("id"))
+	}
+	if id == 0 {
+		http.Error(w, "id required", http.StatusBadRequest)
+		return
+	}
+	var p models.WorkOutProgram
+	if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	p.ID = id
+
+	updated, err := h.Service.UpdateProgram(r.Context(), p)
+	if err != nil {
+		if errors.Is(err, models.ErrWorkoutProgramNotFound) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(updated)
+}
+
+// DeleteProgram removes a program and its days.
+func (h *ProgramHandler) DeleteProgram(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(r.URL.Query().Get(":id"))
+	if id == 0 {
+		id, _ = strconv.Atoi(r.URL.Query().Get("id"))
+	}
+	if id == 0 {
+		http.Error(w, "id required", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.Service.DeleteProgram(r.Context(), id); err != nil {
+		if errors.Is(err, models.ErrWorkoutProgramNotFound) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/models/errors.go
+++ b/internal/models/errors.go
@@ -2,4 +2,10 @@ package models
 
 import "errors"
 
-var ErrInvalidVerificationCode = errors.New("invalid verification code")
+var (
+	ErrInvalidVerificationCode = errors.New("invalid verification code")
+	ErrWorkoutProgramNotFound  = errors.New("workout program not found")
+	ErrExerciseNotFound        = errors.New("exercise not found")
+	ErrFoodNotFound            = errors.New("food not found")
+	ErrDayNotFound             = errors.New("day not found")
+)

--- a/internal/repositories/day_repository.go
+++ b/internal/repositories/day_repository.go
@@ -17,6 +17,9 @@ func (r *DayRepository) GetDayDetails(ctx context.Context, programID, dayNumber 
 	var d models.Days
 	err := r.DB.QueryRowContext(ctx, `SELECT id, work_out_program_id, day_number, exercises_id, food_id, created_at, updated_at FROM days WHERE work_out_program_id=? AND day_number=?`, programID, dayNumber).Scan(&d.ID, &d.WorkOutProgramID, &d.DayNumber, &d.ExercisesID, &d.FoodID, &d.CreatedAt, &d.UpdatedAt)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return models.DayDetails{}, models.ErrDayNotFound
+		}
 		return models.DayDetails{}, err
 	}
 
@@ -50,6 +53,29 @@ func (r *DayRepository) MarkDayCompleted(ctx context.Context, clientID, dayID in
 }
 
 func (r *DayRepository) CreateDay(ctx context.Context, day models.Days) (models.Days, error) {
+	// ensure referenced records exist to avoid foreign key errors
+	var exists bool
+	if err := r.DB.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM workout_programs WHERE id = ?)", day.WorkOutProgramID).Scan(&exists); err != nil {
+		return models.Days{}, err
+	}
+	if !exists {
+		return models.Days{}, models.ErrWorkoutProgramNotFound
+	}
+
+	if err := r.DB.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM exercises WHERE id = ?)", day.ExercisesID).Scan(&exists); err != nil {
+		return models.Days{}, err
+	}
+	if !exists {
+		return models.Days{}, models.ErrExerciseNotFound
+	}
+
+	if err := r.DB.QueryRowContext(ctx, "SELECT EXISTS(SELECT 1 FROM food WHERE id = ?)", day.FoodID).Scan(&exists); err != nil {
+		return models.Days{}, err
+	}
+	if !exists {
+		return models.Days{}, models.ErrFoodNotFound
+	}
+
 	query := `INSERT INTO days (work_out_program_id, day_number, exercises_id, food_id, created_at, updated_at)
                   VALUES (?, ?, ?, ?, ?, ?)`
 	day.CreatedAt = time.Now()
@@ -80,7 +106,7 @@ func (r *DayRepository) DaysByProgram(ctx context.Context, programID int) ([]mod
 	}
 	defer rows.Close()
 
-	var result []models.DayDetails
+	result := []models.DayDetails{}
 	for rows.Next() {
 		var d models.Days
 		var ex models.Exercises

--- a/internal/repositories/program_repository.go
+++ b/internal/repositories/program_repository.go
@@ -43,7 +43,7 @@ WHERE trainer_id = ?
 	}
 	defer rows.Close()
 
-	var programs []models.WorkOutProgram
+	programs := []models.WorkOutProgram{}
 	for rows.Next() {
 		var p models.WorkOutProgram
 		if err := rows.Scan(&p.ID, &p.TrainerID, &p.Name, &p.Days, &p.Description, &p.CreatedAt, &p.UpdatedAt); err != nil {
@@ -52,4 +52,67 @@ WHERE trainer_id = ?
 		programs = append(programs, p)
 	}
 	return programs, rows.Err()
+}
+
+// GetProgramByID fetches a workout program by its ID.
+func (r *ProgramRepository) GetProgramByID(ctx context.Context, id int) (models.WorkOutProgram, error) {
+	var p models.WorkOutProgram
+	query := `SELECT id, trainer_id, name, days, description, created_at, updated_at FROM workout_programs WHERE id = ?`
+	err := r.DB.QueryRowContext(ctx, query, id).Scan(&p.ID, &p.TrainerID, &p.Name, &p.Days, &p.Description, &p.CreatedAt, &p.UpdatedAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return models.WorkOutProgram{}, models.ErrWorkoutProgramNotFound
+		}
+		return models.WorkOutProgram{}, err
+	}
+	return p, nil
+}
+
+// UpdateProgram updates an existing workout program.
+func (r *ProgramRepository) UpdateProgram(ctx context.Context, p models.WorkOutProgram) (models.WorkOutProgram, error) {
+	now := time.Now()
+	p.UpdatedAt = &now
+	query := `UPDATE workout_programs SET name = ?, days = ?, description = ?, updated_at = ? WHERE id = ?`
+	res, err := r.DB.ExecContext(ctx, query, p.Name, p.Days, p.Description, p.UpdatedAt, p.ID)
+	if err != nil {
+		return models.WorkOutProgram{}, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return models.WorkOutProgram{}, err
+	}
+	if rows == 0 {
+		return models.WorkOutProgram{}, models.ErrWorkoutProgramNotFound
+	}
+	return p, nil
+}
+
+// DeleteProgram removes a workout program and all of its days.
+func (r *ProgramRepository) DeleteProgram(ctx context.Context, id int) error {
+	tx, err := r.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+
+	if _, err = tx.ExecContext(ctx, `DELETE FROM days WHERE work_out_program_id = ?`, id); err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	res, err := tx.ExecContext(ctx, `DELETE FROM workout_programs WHERE id = ?`, id)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	if rows == 0 {
+		tx.Rollback()
+		return models.ErrWorkoutProgramNotFound
+	}
+
+	return tx.Commit()
 }

--- a/internal/services/program_service.go
+++ b/internal/services/program_service.go
@@ -19,3 +19,15 @@ func (s *ProgramService) CreateProgram(ctx context.Context, p models.WorkOutProg
 func (s *ProgramService) ProgramsByTrainer(ctx context.Context, trainerID int) ([]models.WorkOutProgram, error) {
 	return s.Repo.GetProgramsByTrainer(ctx, trainerID)
 }
+
+func (s *ProgramService) ProgramByID(ctx context.Context, id int) (models.WorkOutProgram, error) {
+	return s.Repo.GetProgramByID(ctx, id)
+}
+
+func (s *ProgramService) UpdateProgram(ctx context.Context, p models.WorkOutProgram) (models.WorkOutProgram, error) {
+	return s.Repo.UpdateProgram(ctx, p)
+}
+
+func (s *ProgramService) DeleteProgram(ctx context.Context, id int) error {
+	return s.Repo.DeleteProgram(ctx, id)
+}


### PR DESCRIPTION
## Summary
- set trainer ID from auth context when creating programs to ensure they're associated with the correct trainer
- require authentication for listing programs and fall back to the authenticated trainer when no query parameter is supplied
- validate workout program, exercise and food IDs before inserting days so requests fail gracefully
- handle missing program days with a dedicated `day not found` error
- add routes to list all days of a program and to fetch a specific day by number
- implement workout program CRUD operations: get, update and delete

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go build ./cmd` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686bcff4b5a483249083836d1a3b1b88