### PR TITLE
Implement client management via user handler

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -36,6 +36,11 @@ func (app *application) routes() http.Handler {
 	mux.Put("/program/:id", trainerAuthMiddleware.ThenFunc(app.programHandler.UpdateProgram))
 	mux.Del("/program/:id", trainerAuthMiddleware.ThenFunc(app.programHandler.DeleteProgram))
 
+	// Clients
+	mux.Get("/clients", trainerAuthMiddleware.ThenFunc(app.userHandler.GetAllClients))
+	mux.Get("/program/:program_id/clients", trainerAuthMiddleware.ThenFunc(app.userHandler.GetClientsByProgramID))
+	mux.Del("/program/:program_id/client/:client_id", trainerAuthMiddleware.ThenFunc(app.userHandler.DeleteClientFromProgram))
+
 	// Exercises and Food
 	mux.Post("/exercise", trainerAuthMiddleware.ThenFunc(app.exerciseHandler.CreateExercise))
 	mux.Put("/exercise/:id", trainerAuthMiddleware.ThenFunc(app.exerciseHandler.UpdateExercise))
@@ -54,8 +59,6 @@ func (app *application) routes() http.Handler {
 	mux.Del("/program/day/:id", trainerAuthMiddleware.ThenFunc(app.dayHandler.DeleteDay))
 
 	mux.Put("/program/day/:id", trainerAuthMiddleware.ThenFunc(app.dayHandler.UpdateDay))
-
-
 
 	// mux.Get("/swagger/", httpSwagger.WrapHandler)
 

--- a/internal/handlers/user_handler.go
+++ b/internal/handlers/user_handler.go
@@ -1,17 +1,11 @@
 package handlers
 
 import (
-	_ "context"
 	"encoding/json"
 	"errors"
-	_ "fmt"
-	_ "io"
 	"log"
 	"net/http"
-	_ "os"
-	_ "path/filepath"
-	_ "strconv"
-	_ "time"
+	"strconv"
 
 	"workout/internal/models"
 	"workout/internal/services"
@@ -103,5 +97,56 @@ func (h *UserHandler) UpgradeToTrainer(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// GetAllClients returns all users with client role.
+func (h *UserHandler) GetAllClients(w http.ResponseWriter, r *http.Request) {
+	clients, err := h.Service.GetAllClients(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(clients)
+}
+
+// GetClientsByProgramID lists clients participating in a program.
+func (h *UserHandler) GetClientsByProgramID(w http.ResponseWriter, r *http.Request) {
+	programID, _ := strconv.Atoi(r.URL.Query().Get(":program_id"))
+	if programID == 0 {
+		programID, _ = strconv.Atoi(r.URL.Query().Get("program_id"))
+	}
+	if programID == 0 {
+		http.Error(w, "program_id required", http.StatusBadRequest)
+		return
+	}
+	clients, err := h.Service.GetClientsByProgramID(r.Context(), programID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(clients)
+}
+
+// DeleteClientFromProgram removes a client's progress from a program.
+func (h *UserHandler) DeleteClientFromProgram(w http.ResponseWriter, r *http.Request) {
+	programID, _ := strconv.Atoi(r.URL.Query().Get(":program_id"))
+	if programID == 0 {
+		programID, _ = strconv.Atoi(r.URL.Query().Get("program_id"))
+	}
+	clientID, _ := strconv.Atoi(r.URL.Query().Get(":client_id"))
+	if clientID == 0 {
+		clientID, _ = strconv.Atoi(r.URL.Query().Get("client_id"))
+	}
+	if programID == 0 || clientID == 0 {
+		http.Error(w, "program_id and client_id required", http.StatusBadRequest)
+		return
+	}
+	if err := h.Service.DeleteClientFromProgram(r.Context(), programID, clientID); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/repositories/user_repository.go
+++ b/internal/repositories/user_repository.go
@@ -135,3 +135,50 @@ func (r *UserRepository) UpdateUserRole(ctx context.Context, userID int, role st
 	_, err := r.DB.ExecContext(ctx, `UPDATE users SET role = ?, updated_at = ? WHERE id = ?`, role, time.Now(), userID)
 	return err
 }
+
+func (r *UserRepository) GetAllClients(ctx context.Context) ([]models.User, error) {
+	rows, err := r.DB.QueryContext(ctx, `SELECT id, name, phone, email, password, role, created_at, updated_at FROM users WHERE role = 'client'`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []models.User
+	for rows.Next() {
+		var u models.User
+		if err := rows.Scan(&u.ID, &u.Name, &u.Phone, &u.Email, &u.Password, &u.Role, &u.CreatedAt, &u.UpdatedAt); err != nil {
+			return nil, err
+		}
+		result = append(result, u)
+	}
+	return result, rows.Err()
+}
+
+func (r *UserRepository) GetClientsByProgramID(ctx context.Context, programID int) ([]models.User, error) {
+	query := `SELECT DISTINCT u.id, u.name, u.phone, u.email, u.password, u.role, u.created_at, u.updated_at
+              FROM users u
+              JOIN progress p ON u.id = p.client_id
+              JOIN days d ON p.day_id = d.id
+              WHERE d.work_out_program_id = ?`
+	rows, err := r.DB.QueryContext(ctx, query, programID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []models.User
+	for rows.Next() {
+		var u models.User
+		if err := rows.Scan(&u.ID, &u.Name, &u.Phone, &u.Email, &u.Password, &u.Role, &u.CreatedAt, &u.UpdatedAt); err != nil {
+			return nil, err
+		}
+		result = append(result, u)
+	}
+	return result, rows.Err()
+}
+
+func (r *UserRepository) DeleteClientFromProgram(ctx context.Context, programID, clientID int) error {
+	query := `DELETE p FROM progress p JOIN days d ON p.day_id = d.id WHERE d.work_out_program_id = ? AND p.client_id = ?`
+	_, err := r.DB.ExecContext(ctx, query, programID, clientID)
+	return err
+}

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -150,3 +150,15 @@ func (s *UserService) SignUp(ctx context.Context, user models.User, inputCode st
 func (s *UserService) UpgradeToTrainer(ctx context.Context, userID int) error {
 	return s.UserRepo.UpdateUserRole(ctx, userID, "trainer")
 }
+
+func (s *UserService) GetAllClients(ctx context.Context) ([]models.User, error) {
+	return s.UserRepo.GetAllClients(ctx)
+}
+
+func (s *UserService) GetClientsByProgramID(ctx context.Context, programID int) ([]models.User, error) {
+	return s.UserRepo.GetClientsByProgramID(ctx, programID)
+}
+
+func (s *UserService) DeleteClientFromProgram(ctx context.Context, programID, clientID int) error {
+	return s.UserRepo.DeleteClientFromProgram(ctx, programID, clientID)
+}


### PR DESCRIPTION
## Summary
- integrate client-related endpoints within `UserHandler`
- extend `UserService` and `UserRepository` with client management methods
- add routes for listing clients, listing program clients and deleting client progress
- remove now-unnecessary `ClientHandler`, `ClientService`, and `ClientRepository`

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686d1622b1b48324a6f5a11b621f447e