### PR TITLE
Implement programs-by-client lookup

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -36,6 +36,12 @@ func (app *application) routes() http.Handler {
 	mux.Put("/program/:id", trainerAuthMiddleware.ThenFunc(app.programHandler.UpdateProgram))
 	mux.Del("/program/:id", trainerAuthMiddleware.ThenFunc(app.programHandler.DeleteProgram))
 
+	// Clients
+	mux.Get("/clients", trainerAuthMiddleware.ThenFunc(app.userHandler.GetAllClients))
+	mux.Get("/program/:program_id/clients", trainerAuthMiddleware.ThenFunc(app.userHandler.GetClientsByProgramID))
+	mux.Del("/program/:program_id/client/:client_id", trainerAuthMiddleware.ThenFunc(app.userHandler.DeleteClientFromProgram))
+	mux.Get("/client/:client_id/programs", trainerAuthMiddleware.ThenFunc(app.userHandler.GetProgramsByClientID))
+
 	// Exercises and Food
 	mux.Post("/exercise", trainerAuthMiddleware.ThenFunc(app.exerciseHandler.CreateExercise))
 	mux.Put("/exercise/:id", trainerAuthMiddleware.ThenFunc(app.exerciseHandler.UpdateExercise))
@@ -54,8 +60,6 @@ func (app *application) routes() http.Handler {
 	mux.Del("/program/day/:id", trainerAuthMiddleware.ThenFunc(app.dayHandler.DeleteDay))
 
 	mux.Put("/program/day/:id", trainerAuthMiddleware.ThenFunc(app.dayHandler.UpdateDay))
-
-
 
 	// mux.Get("/swagger/", httpSwagger.WrapHandler)
 

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -150,3 +150,18 @@ func (s *UserService) SignUp(ctx context.Context, user models.User, inputCode st
 func (s *UserService) UpgradeToTrainer(ctx context.Context, userID int) error {
 	return s.UserRepo.UpdateUserRole(ctx, userID, "trainer")
 }
+
+func (s *UserService) GetAllClients(ctx context.Context) ([]models.User, error) {
+	return s.UserRepo.GetAllClients(ctx)
+}
+
+func (s *UserService) GetClientsByProgramID(ctx context.Context, programID int) ([]models.User, error) {
+	return s.UserRepo.GetClientsByProgramID(ctx, programID)
+}
+
+func (s *UserService) DeleteClientFromProgram(ctx context.Context, programID, clientID int) error {
+	return s.UserRepo.DeleteClientFromProgram(ctx, programID, clientID)
+}
+func (s *UserService) GetProgramsByClientID(ctx context.Context, clientID int) ([]models.WorkOutProgram, error) {
+	return s.UserRepo.GetProgramsByClientID(ctx, clientID)
+}


### PR DESCRIPTION
## Summary
- support listing workout programs for a specific client
- connect new repository, service and handler methods
- expose route `/client/:client_id/programs`

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686d1622b1b48324a6f5a11b621f447e