### PR TITLE
Add per-day food/exercise progress tracking

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -54,6 +54,9 @@ func (app *application) routes() http.Handler {
 	mux.Get("/program/:program_id/days", trainerAuthMiddleware.ThenFunc(app.dayHandler.DaysByProgram))
 	mux.Get("/program/:program_id/day/:day", trainerAuthMiddleware.ThenFunc(app.dayHandler.DayDetails))
 	mux.Post("/program/day/complete", standardMiddleware.ThenFunc(app.dayHandler.CompleteDay))
+	mux.Post("/program/day/food", standardMiddleware.ThenFunc(app.dayHandler.CompleteFood))
+	mux.Post("/program/day/exercise", standardMiddleware.ThenFunc(app.dayHandler.CompleteExercise))
+	mux.Get("/program/day/progress", standardMiddleware.ThenFunc(app.dayHandler.ProgressStatus))
 	mux.Post("/program/day", trainerAuthMiddleware.ThenFunc(app.dayHandler.CreateDay))
 
 	mux.Put("/program/day/:id", trainerAuthMiddleware.ThenFunc(app.dayHandler.UpdateDay))

--- a/db/migrations/000007_progress.up.sql
+++ b/db/migrations/000007_progress.up.sql
@@ -1,10 +1,12 @@
 CREATE TABLE IF NOT EXISTS progress (
-                                        id INT AUTO_INCREMENT PRIMARY KEY,
-                                        client_id INT NOT NULL,
-                                        day_id INT NOT NULL,
-                                        completed DATETIME NOT NULL,
-                                        FOREIGN KEY (client_id) REFERENCES users(id),
-                                        FOREIGN KEY (day_id) REFERENCES days(id)
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    client_id INT NOT NULL,
+    day_id INT NOT NULL,
+    food_completed BOOLEAN NOT NULL DEFAULT FALSE,
+    exercise_completed BOOLEAN NOT NULL DEFAULT FALSE,
+    completed DATETIME,
+    UNIQUE KEY client_day_unique (client_id, day_id),
+    FOREIGN KEY (client_id) REFERENCES users(id),
+    FOREIGN KEY (day_id) REFERENCES days(id)
 );
-
-use workout;
+USE workout;

--- a/internal/handlers/day_handler.go
+++ b/internal/handlers/day_handler.go
@@ -65,6 +65,62 @@ func (h *DayHandler) CompleteDay(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(progress)
 }
+
+func (h *DayHandler) CompleteFood(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ClientID int `json:"client_id"`
+		DayID    int `json:"day_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	progress, err := h.Service.CompleteFood(r.Context(), req.ClientID, req.DayID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(progress)
+}
+
+func (h *DayHandler) CompleteExercise(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ClientID int `json:"client_id"`
+		DayID    int `json:"day_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	progress, err := h.Service.CompleteExercise(r.Context(), req.ClientID, req.DayID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(progress)
+}
+
+func (h *DayHandler) ProgressStatus(w http.ResponseWriter, r *http.Request) {
+	clientID, _ := strconv.Atoi(r.URL.Query().Get("client_id"))
+	dayID, _ := strconv.Atoi(r.URL.Query().Get("day_id"))
+	if clientID == 0 || dayID == 0 {
+		http.Error(w, "client_id and day_id required", http.StatusBadRequest)
+		return
+	}
+	progress, err := h.Service.GetProgress(r.Context(), clientID, dayID)
+	if err != nil {
+		if errors.Is(err, models.ErrDayNotFound) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(progress)
+}
 func (h *DayHandler) CreateDay(w http.ResponseWriter, r *http.Request) {
 	var day models.Days
 	if err := json.NewDecoder(r.Body).Decode(&day); err != nil {
@@ -141,7 +197,6 @@ func (h *DayHandler) UpdateDay(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(updated)
 }
 
-
 // DeleteDay removes a workout day by id.
 func (h *DayHandler) DeleteDay(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(r.URL.Query().Get(":id"))
@@ -164,4 +219,3 @@ func (h *DayHandler) DeleteDay(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusNoContent)
 }
-

--- a/internal/models/progress.go
+++ b/internal/models/progress.go
@@ -12,8 +12,10 @@ type DayDetails struct {
 
 // ProgramProgress represents completion of a workout day by a client.
 type ProgramProgress struct {
-	ID        int       `json:"id"`
-	ClientID  int       `json:"client_id"`
-	DayID     int       `json:"day_id"`
-	Completed time.Time `json:"completed"`
+	ID                int        `json:"id"`
+	ClientID          int        `json:"client_id"`
+	DayID             int        `json:"day_id"`
+	FoodCompleted     bool       `json:"food_completed"`
+	ExerciseCompleted bool       `json:"exercise_completed"`
+	Completed         *time.Time `json:"completed,omitempty"`
 }

--- a/internal/services/day_service.go
+++ b/internal/services/day_service.go
@@ -19,6 +19,18 @@ func (s *DayService) CompleteDay(ctx context.Context, clientID, dayID int) (mode
 	return s.Repo.MarkDayCompleted(ctx, clientID, dayID)
 }
 
+func (s *DayService) CompleteFood(ctx context.Context, clientID, dayID int) (models.ProgramProgress, error) {
+	return s.Repo.MarkFoodCompleted(ctx, clientID, dayID)
+}
+
+func (s *DayService) CompleteExercise(ctx context.Context, clientID, dayID int) (models.ProgramProgress, error) {
+	return s.Repo.MarkExerciseCompleted(ctx, clientID, dayID)
+}
+
+func (s *DayService) GetProgress(ctx context.Context, clientID, dayID int) (models.ProgramProgress, error) {
+	return s.Repo.GetProgress(ctx, clientID, dayID)
+}
+
 func (s *DayService) CreateDay(ctx context.Context, day models.Days) (models.Days, error) {
 	return s.Repo.CreateDay(ctx, day)
 }
@@ -31,9 +43,6 @@ func (s *DayService) UpdateDay(ctx context.Context, day models.Days) (models.Day
 	return s.Repo.UpdateDay(ctx, day)
 }
 
-
 func (s *DayService) DeleteDay(ctx context.Context, id int) error {
 	return s.Repo.DeleteDay(ctx, id)
 }
-
-


### PR DESCRIPTION
## Summary
- track food/exercise completion separately
- expose new service and repository methods for marking food/exercise done
- add HTTP handlers and routes to set and query progress
- update progress schema to store food and exercise flags

## Testing
- `go vet ./...` *(fails: Forbidden - proxy.golang.org)*
- `go test ./...` *(fails: Forbidden - proxy.golang.org)*

------
https://chatgpt.com/codex/tasks/task_e_686e225df0cc8324a170691feed6353a