### PR TITLE
Add program progress endpoints

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -54,6 +54,10 @@ func (app *application) routes() http.Handler {
 	mux.Get("/program/:program_id/days", trainerAuthMiddleware.ThenFunc(app.dayHandler.DaysByProgram))
 	mux.Get("/program/:program_id/day/:day", trainerAuthMiddleware.ThenFunc(app.dayHandler.DayDetails))
 	mux.Post("/program/day/complete", standardMiddleware.ThenFunc(app.dayHandler.CompleteDay))
+	mux.Post("/program/day/food", standardMiddleware.ThenFunc(app.dayHandler.CompleteFood))
+	mux.Post("/program/day/exercise", standardMiddleware.ThenFunc(app.dayHandler.CompleteExercise))
+	mux.Get("/program/day/progress", standardMiddleware.ThenFunc(app.dayHandler.ProgressStatus))
+	mux.Get("/program/:program_id/progress", standardMiddleware.ThenFunc(app.dayHandler.ProgramProgress))
 	mux.Post("/program/day", trainerAuthMiddleware.ThenFunc(app.dayHandler.CreateDay))
 
 	mux.Put("/program/day/:id", trainerAuthMiddleware.ThenFunc(app.dayHandler.UpdateDay))

--- a/db/migrations/000007_progress.up.sql
+++ b/db/migrations/000007_progress.up.sql
@@ -1,10 +1,12 @@
 CREATE TABLE IF NOT EXISTS progress (
-                                        id INT AUTO_INCREMENT PRIMARY KEY,
-                                        client_id INT NOT NULL,
-                                        day_id INT NOT NULL,
-                                        completed DATETIME NOT NULL,
-                                        FOREIGN KEY (client_id) REFERENCES users(id),
-                                        FOREIGN KEY (day_id) REFERENCES days(id)
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    client_id INT NOT NULL,
+    day_id INT NOT NULL,
+    food_completed BOOLEAN NOT NULL DEFAULT FALSE,
+    exercise_completed BOOLEAN NOT NULL DEFAULT FALSE,
+    completed DATETIME,
+    UNIQUE KEY client_day_unique (client_id, day_id),
+    FOREIGN KEY (client_id) REFERENCES users(id),
+    FOREIGN KEY (day_id) REFERENCES days(id)
 );
-
-use workout;
+USE workout;

--- a/internal/handlers/day_handler.go
+++ b/internal/handlers/day_handler.go
@@ -65,6 +65,78 @@ func (h *DayHandler) CompleteDay(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(progress)
 }
+
+func (h *DayHandler) CompleteFood(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ClientID int `json:"client_id"`
+		DayID    int `json:"day_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	progress, err := h.Service.CompleteFood(r.Context(), req.ClientID, req.DayID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(progress)
+}
+
+func (h *DayHandler) CompleteExercise(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ClientID int `json:"client_id"`
+		DayID    int `json:"day_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	progress, err := h.Service.CompleteExercise(r.Context(), req.ClientID, req.DayID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(progress)
+}
+
+func (h *DayHandler) ProgressStatus(w http.ResponseWriter, r *http.Request) {
+	clientID, _ := strconv.Atoi(r.URL.Query().Get("client_id"))
+	dayID, _ := strconv.Atoi(r.URL.Query().Get("day_id"))
+	if clientID == 0 || dayID == 0 {
+		http.Error(w, "client_id and day_id required", http.StatusBadRequest)
+		return
+	}
+	progress, err := h.Service.GetProgress(r.Context(), clientID, dayID)
+	if err != nil {
+		if errors.Is(err, models.ErrDayNotFound) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(progress)
+}
+
+func (h *DayHandler) ProgramProgress(w http.ResponseWriter, r *http.Request) {
+	clientID, _ := strconv.Atoi(r.URL.Query().Get("client_id"))
+	programID, _ := strconv.Atoi(r.URL.Query().Get("program_id"))
+	if clientID == 0 || programID == 0 {
+		http.Error(w, "client_id and program_id required", http.StatusBadRequest)
+		return
+	}
+	progress, err := h.Service.GetProgramProgress(r.Context(), clientID, programID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(progress)
+}
 func (h *DayHandler) CreateDay(w http.ResponseWriter, r *http.Request) {
 	var day models.Days
 	if err := json.NewDecoder(r.Body).Decode(&day); err != nil {
@@ -141,7 +213,6 @@ func (h *DayHandler) UpdateDay(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(updated)
 }
 
-
 // DeleteDay removes a workout day by id.
 func (h *DayHandler) DeleteDay(w http.ResponseWriter, r *http.Request) {
 	id, _ := strconv.Atoi(r.URL.Query().Get(":id"))
@@ -164,4 +235,3 @@ func (h *DayHandler) DeleteDay(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusNoContent)
 }
-

--- a/internal/models/progress.go
+++ b/internal/models/progress.go
@@ -12,8 +12,19 @@ type DayDetails struct {
 
 // ProgramProgress represents completion of a workout day by a client.
 type ProgramProgress struct {
-	ID        int       `json:"id"`
-	ClientID  int       `json:"client_id"`
-	DayID     int       `json:"day_id"`
-	Completed time.Time `json:"completed"`
+	ID                int        `json:"id"`
+	ClientID          int        `json:"client_id"`
+	DayID             int        `json:"day_id"`
+	FoodCompleted     bool       `json:"food_completed"`
+	ExerciseCompleted bool       `json:"exercise_completed"`
+	Completed         *time.Time `json:"completed,omitempty"`
+}
+
+// DayProgressStatus exposes completion info for a program's day.
+type DayProgressStatus struct {
+	DayID             int        `json:"day_id"`
+	DayNumber         int        `json:"day_number"`
+	FoodCompleted     bool       `json:"food_completed"`
+	ExerciseCompleted bool       `json:"exercise_completed"`
+	Completed         *time.Time `json:"completed,omitempty"`
 }

--- a/internal/repositories/day_repository.go
+++ b/internal/repositories/day_repository.go
@@ -39,17 +39,118 @@ func (r *DayRepository) GetDayDetails(ctx context.Context, programID, dayNumber 
 }
 
 func (r *DayRepository) MarkDayCompleted(ctx context.Context, clientID, dayID int) (models.ProgramProgress, error) {
-	prog := models.ProgramProgress{ClientID: clientID, DayID: dayID, Completed: time.Now()}
-	res, err := r.DB.ExecContext(ctx, `INSERT INTO progress (client_id, day_id, completed) VALUES (?, ?, ?)`, prog.ClientID, prog.DayID, prog.Completed)
+	now := time.Now()
+	// try update existing progress record
+	res, err := r.DB.ExecContext(ctx, `UPDATE progress SET completed = ? WHERE client_id = ? AND day_id = ?`, now, clientID, dayID)
 	if err != nil {
 		return models.ProgramProgress{}, err
 	}
-	id, err := res.LastInsertId()
+	rows, err := res.RowsAffected()
 	if err != nil {
 		return models.ProgramProgress{}, err
 	}
-	prog.ID = int(id)
+	if rows == 0 {
+		// insert new progress if none exists
+		res, err = r.DB.ExecContext(ctx, `INSERT INTO progress (client_id, day_id, food_completed, exercise_completed, completed) VALUES (?, ?, false, false, ?)`, clientID, dayID, now)
+		if err != nil {
+			return models.ProgramProgress{}, err
+		}
+	}
+
+	var prog models.ProgramProgress
+	var completed sql.NullTime
+	err = r.DB.QueryRowContext(ctx, `SELECT id, client_id, day_id, food_completed, exercise_completed, completed FROM progress WHERE client_id = ? AND day_id = ?`, clientID, dayID).Scan(
+		&prog.ID, &prog.ClientID, &prog.DayID, &prog.FoodCompleted, &prog.ExerciseCompleted, &completed)
+	if err != nil {
+		return models.ProgramProgress{}, err
+	}
+	if completed.Valid {
+		prog.Completed = &completed.Time
+	}
 	return prog, nil
+}
+
+func (r *DayRepository) MarkFoodCompleted(ctx context.Context, clientID, dayID int) (models.ProgramProgress, error) {
+	res, err := r.DB.ExecContext(ctx, `UPDATE progress SET food_completed = TRUE WHERE client_id = ? AND day_id = ?`, clientID, dayID)
+	if err != nil {
+		return models.ProgramProgress{}, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return models.ProgramProgress{}, err
+	}
+	if rows == 0 {
+		res, err = r.DB.ExecContext(ctx, `INSERT INTO progress (client_id, day_id, food_completed, exercise_completed) VALUES (?, ?, TRUE, FALSE)`, clientID, dayID)
+		if err != nil {
+			return models.ProgramProgress{}, err
+		}
+	}
+	return r.GetProgress(ctx, clientID, dayID)
+}
+
+func (r *DayRepository) MarkExerciseCompleted(ctx context.Context, clientID, dayID int) (models.ProgramProgress, error) {
+	res, err := r.DB.ExecContext(ctx, `UPDATE progress SET exercise_completed = TRUE WHERE client_id = ? AND day_id = ?`, clientID, dayID)
+	if err != nil {
+		return models.ProgramProgress{}, err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return models.ProgramProgress{}, err
+	}
+	if rows == 0 {
+		res, err = r.DB.ExecContext(ctx, `INSERT INTO progress (client_id, day_id, food_completed, exercise_completed) VALUES (?, ?, FALSE, TRUE)`, clientID, dayID)
+		if err != nil {
+			return models.ProgramProgress{}, err
+		}
+	}
+	return r.GetProgress(ctx, clientID, dayID)
+}
+
+func (r *DayRepository) GetProgress(ctx context.Context, clientID, dayID int) (models.ProgramProgress, error) {
+	var prog models.ProgramProgress
+	var completed sql.NullTime
+	err := r.DB.QueryRowContext(ctx, `SELECT id, client_id, day_id, food_completed, exercise_completed, completed FROM progress WHERE client_id = ? AND day_id = ?`, clientID, dayID).Scan(
+		&prog.ID, &prog.ClientID, &prog.DayID, &prog.FoodCompleted, &prog.ExerciseCompleted, &completed)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return models.ProgramProgress{}, models.ErrDayNotFound
+		}
+		return models.ProgramProgress{}, err
+	}
+	if completed.Valid {
+		prog.Completed = &completed.Time
+	}
+	return prog, nil
+}
+
+// GetProgramProgress returns progress info for all days in a program for a client.
+func (r *DayRepository) GetProgramProgress(ctx context.Context, clientID, programID int) ([]models.DayProgressStatus, error) {
+	rows, err := r.DB.QueryContext(ctx, `SELECT d.id, d.day_number,
+        COALESCE(p.food_completed, FALSE),
+        COALESCE(p.exercise_completed, FALSE),
+        p.completed
+        FROM days d
+        LEFT JOIN progress p ON p.day_id = d.id AND p.client_id = ?
+        WHERE d.work_out_program_id = ?
+        ORDER BY d.day_number`, clientID, programID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []models.DayProgressStatus
+	for rows.Next() {
+		var dp models.DayProgressStatus
+		var completed sql.NullTime
+		if err := rows.Scan(&dp.DayID, &dp.DayNumber, &dp.FoodCompleted, &dp.ExerciseCompleted, &completed); err != nil {
+			return nil, err
+		}
+		if completed.Valid {
+			dp.Completed = &completed.Time
+		}
+		result = append(result, dp)
+	}
+	return result, rows.Err()
 }
 
 func (r *DayRepository) CreateDay(ctx context.Context, day models.Days) (models.Days, error) {

--- a/internal/services/day_service.go
+++ b/internal/services/day_service.go
@@ -19,6 +19,22 @@ func (s *DayService) CompleteDay(ctx context.Context, clientID, dayID int) (mode
 	return s.Repo.MarkDayCompleted(ctx, clientID, dayID)
 }
 
+func (s *DayService) CompleteFood(ctx context.Context, clientID, dayID int) (models.ProgramProgress, error) {
+	return s.Repo.MarkFoodCompleted(ctx, clientID, dayID)
+}
+
+func (s *DayService) CompleteExercise(ctx context.Context, clientID, dayID int) (models.ProgramProgress, error) {
+	return s.Repo.MarkExerciseCompleted(ctx, clientID, dayID)
+}
+
+func (s *DayService) GetProgress(ctx context.Context, clientID, dayID int) (models.ProgramProgress, error) {
+	return s.Repo.GetProgress(ctx, clientID, dayID)
+}
+
+func (s *DayService) GetProgramProgress(ctx context.Context, clientID, programID int) ([]models.DayProgressStatus, error) {
+	return s.Repo.GetProgramProgress(ctx, clientID, programID)
+}
+
 func (s *DayService) CreateDay(ctx context.Context, day models.Days) (models.Days, error) {
 	return s.Repo.CreateDay(ctx, day)
 }
@@ -31,9 +47,6 @@ func (s *DayService) UpdateDay(ctx context.Context, day models.Days) (models.Day
 	return s.Repo.UpdateDay(ctx, day)
 }
 
-
 func (s *DayService) DeleteDay(ctx context.Context, id int) error {
 	return s.Repo.DeleteDay(ctx, id)
 }
-
-


### PR DESCRIPTION
## Summary
- support listing all progress for a client's program
- expose handler and route to fetch program progress
- add DayProgressStatus model and repository/service methods

## Testing
- `go vet ./...` *(fails: Forbidden - proxy.golang.org)*
- `go test ./...` *(fails: Forbidden - proxy.golang.org)*

------
https://chatgpt.com/codex/tasks/task_e_686e225df0cc8324a170691feed6353a