### PR TITLE
Add client to program on invite acceptance

### DIFF
--- a/internal/repositories/user_repository.go
+++ b/internal/repositories/user_repository.go
@@ -217,6 +217,13 @@ func (r *UserRepository) GetClientsByProgramID(ctx context.Context, programID in
 	return result, rows.Err()
 }
 
+func (r *UserRepository) AddClientToProgram(ctx context.Context, programID, clientID int) error {
+	query := `INSERT IGNORE INTO progress (client_id, day_id, food_completed, exercise_completed)
+               SELECT ?, d.id, FALSE, FALSE FROM days d WHERE d.work_out_program_id = ?`
+	_, err := r.DB.ExecContext(ctx, query, clientID, programID)
+	return err
+}
+
 func (r *UserRepository) DeleteClientFromProgram(ctx context.Context, programID, clientID int) error {
 	query := `DELETE p FROM progress p JOIN days d ON p.day_id = d.id WHERE d.work_out_program_id = ? AND p.client_id = ?`
 	_, err := r.DB.ExecContext(ctx, query, programID, clientID)

--- a/internal/services/invite_service.go
+++ b/internal/services/invite_service.go
@@ -24,7 +24,14 @@ func (s *InviteService) InviteClient(ctx context.Context, programID int, email, 
 }
 
 func (s *InviteService) AcceptInvite(ctx context.Context, token string, clientID int) (models.ProgramInvite, error) {
-	return s.Repo.AcceptInvite(ctx, token, clientID)
+	inv, err := s.Repo.AcceptInvite(ctx, token, clientID)
+	if err != nil {
+		return inv, err
+	}
+	if err := s.UserRepo.AddClientToProgram(ctx, inv.ProgramID, clientID); err != nil {
+		return inv, err
+	}
+	return inv, nil
 }
 
 func (s *InviteService) UpdateAccess(ctx context.Context, programID, clientID, days int) (models.ProgramInvite, error) {


### PR DESCRIPTION
## Summary
- automatically enroll clients in program when accepting invite by adding progress records
- expose repository helper to add all program days for a client

## Testing
- `go test ./...` *(failed: command produced no output)*

------
https://chatgpt.com/codex/tasks/task_e_689058e5c4a0832481727ed9e7071c3e