### PR TITLE
Add client to program on invite acceptance

### DIFF
--- a/internal/services/invite_service.go
+++ b/internal/services/invite_service.go
@@ -24,7 +24,14 @@ func (s *InviteService) InviteClient(ctx context.Context, programID int, email, 
 }
 
 func (s *InviteService) AcceptInvite(ctx context.Context, token string, clientID int) (models.ProgramInvite, error) {
-	return s.Repo.AcceptInvite(ctx, token, clientID)
+	inv, err := s.Repo.AcceptInvite(ctx, token, clientID)
+	if err != nil {
+		return inv, err
+	}
+	if err := s.UserRepo.AddClientToProgram(ctx, inv.ProgramID, clientID); err != nil {
+		return inv, err
+	}
+	return inv, nil
 }
 
 func (s *InviteService) UpdateAccess(ctx context.Context, programID, clientID, days int) (models.ProgramInvite, error) {


### PR DESCRIPTION
## Summary
- automatically enroll clients in program when accepting invite by adding progress records
- expose repository helper to add all program days for a client
- simplify program-client lookup to rely on progress records so accepted clients appear in queries

## Testing
- `go test ./...` *(no test files)*

------
https://chatgpt.com/codex/tasks/task_e_689058e5c4a0832481727ed9e7071c3e